### PR TITLE
association of warehouses to projects

### DIFF
--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -505,7 +505,7 @@ class FormProjets
 		}
 
 		$linkedtothirdparty = false;
-		if (!in_array($table_element, array('don', 'expensereport_det', 'expensereport', 'loan', 'stock_mouvement', 'payment_salary', 'payment_various', 'chargesociales'))) {
+		if (!in_array($table_element, array('don', 'expensereport_det', 'expensereport', 'loan', 'stock_mouvement', 'payment_salary', 'payment_various', 'chargesociales', 'entrepot'))) {
 			$linkedtothirdparty = true;
 		}
 

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -89,6 +89,7 @@ TimeConsumed=Consumed
 ListOfTasks=List of tasks
 GoToListOfTimeConsumed=Go to list of time consumed
 GanttView=Gantt View
+ListWarehouseAssociatedProject=List of warehouses associated to the project
 ListProposalsAssociatedProject=List of the commercial proposals related to the project
 ListOrdersAssociatedProject=List of sales orders related to the project
 ListInvoicesAssociatedProject=List of customer invoices related to the project

--- a/htdocs/langs/fr_FR/projects.lang
+++ b/htdocs/langs/fr_FR/projects.lang
@@ -89,6 +89,7 @@ TimeConsumed=Consommé
 ListOfTasks=Liste de tâches
 GoToListOfTimeConsumed=Aller à la liste des temps consommés
 GanttView=Vue Gantt
+ListWarehouseAssociatedProject=Liste des entrepôts associés au projet
 ListProposalsAssociatedProject=Liste des propositions commerciales associées au projet
 ListOrdersAssociatedProject=Liste des commandes clients associées au projet
 ListInvoicesAssociatedProject=Liste des factures clients associées au projet

--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -41,6 +41,7 @@ $langs->loadLangs(array('products', 'stocks', 'companies', 'categories'));
 $action = GETPOST('action', 'aZ09');
 $cancel = GETPOST('cancel', 'alpha');
 $confirm = GETPOST('confirm');
+$projectid = GETPOST('projectid', 'int');
 
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref', 'alpha');

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -1778,6 +1778,9 @@ class Project extends CommonObject
 		if ($tableName == "actioncomm") {
 			$sql .= " SET fk_project=".$this->id;
 			$sql .= " WHERE id=".$elementSelectId;
+		} elseif ($tableName == "entrepot") {
+			$sql .= " SET fk_project=".$this->id;
+			$sql .= " WHERE rowid=".$elementSelectId;
 		} else {
 			$sql .= " SET fk_projet=".$this->id;
 			$sql .= " WHERE rowid=".$elementSelectId;

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -367,7 +367,7 @@ $listofreferent = array(
 	'class'=>'Entrepot',
 	'table'=>'entrepot',
 	'datefieldname'=>'date_entrepot',
-	'urlnew'=>DOL_URL_ROOT.'/product/stock/card.php?action=create&origin=project&originid='.$id,
+	'urlnew'=>DOL_URL_ROOT.'/product/stock/card.php?action=create&projectid='.$id,
 	'lang'=>'entrepot',
 	'buttonnew'=>'AddWarehouse',
 	'project_field'=>'fk_project',

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
  * Copyright (C) 2016      Josep Lluís Amador   <joseplluis@lliuretic.cat>
  * Copyright (C) 2021		Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2021      Noé Cendrier         <noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -360,6 +361,18 @@ print '<br>';
  */
 
 $listofreferent = array(
+'entrepot'=>array(
+	'name'=>"Warehouse",
+	'title'=>"ListWarehouseAssociatedProject",
+	'class'=>'Entrepot',
+	'table'=>'entrepot',
+	'datefieldname'=>'date_entrepot',
+	'urlnew'=>DOL_URL_ROOT.'/product/stock/card.php?action=create&origin=project&originid='.$id,
+	'lang'=>'entrepot',
+	'buttonnew'=>'AddWarehouse',
+	'project_field'=>'fk_project',
+	'testnew'=>$user->rights->stock->creer,
+	'test'=>$conf->stock->enabled && $user->rights->stock->lire),
 'propal'=>array(
 	'name'=>"Proposals",
 	'title'=>"ListProposalsAssociatedProject",


### PR DESCRIPTION
# Gestion des entrepôts depuis la vue d’ensemble du projet
On peut : 
- voir les entrepôts appartenant au projet
- sélectionner les entrepôts disponible pour ajoût
- lancer la création d’un nouvel entrepôt
Pas encore finalisé (dépend de la PR précédente) :
- [x] présélectionner le projet dans le nouvel entrepôt en création.

cc @altairis-tof pour relecture.
