### PR TITLE
Fix: Statut ticket

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -458,7 +458,7 @@ if (empty($reshook)) {
 	// Action to add a message (private or not, with email or not).
 	// This may also send an email (concatenated with email_intro and email footer if checkbox was selected)
 	if ($action == 'add_message' && GETPOSTISSET('btn_add_message') && $permissiontoread) {
-		$ret = $object->newMessage($user, $action, (GETPOST('private_message', 'alpha') == "on" ? 1 : 0), 0);
+		$ret = $object->newMessage($user, $action, GETPOSTINT('private_message'), 0);
 
 		if ($ret > 0) {
 			if (!empty($backtopage)) {


### PR DESCRIPTION
When we send a trapped message from the ticket with the option "Automatically assign a status when answering a ticket", on waiting for feedback. The ticket automatically goes to waiting for feedback because when call the newMessage function, the check on GETPOST('private_message, alpha') is not correct and returns zero instead of one.