### PR TITLE
NEW:  Add the "packaging" feature to round the quantities to some given multiples

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -709,6 +709,20 @@ class Propal extends CommonObject
 
 			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc);
 
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				$product = new Product($this->db);
+				$result = $product->fetch($fk_product);
+				if ($qty < $product->packaging) {
+					$qty = $product->packaging;
+				} else {
+					if (!empty($product->packaging) && (fmod((float) $qty, $product->packaging)  > 0.000001)) {
+						$coeff = intval((float) $qty / $product->packaging) + 1;
+						$qty = (float) $product->packaging * $coeff;
+						setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'mesgs');
+					}
+				}
+			}
+
 			// Clean vat code
 			$reg = array();
 			$vat_src_code = '';
@@ -972,6 +986,18 @@ class Propal extends CommonObject
 			if (!empty($fk_parent_line) && !empty($staticline->fk_parent_line) && $fk_parent_line != $staticline->fk_parent_line) {
 				$rangmax = $this->line_max($fk_parent_line);
 				$this->line->rang = $rangmax + 1;
+			}
+
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				if ($qty < $this->line->packaging) {
+					$qty = $this->line->packaging;
+				} else {
+					if (!empty($this->line->packaging) && ($qty % $this->line->packaging) > 0) {
+						$coeff = intval($qty / $this->line->packaging) + 1;
+						$qty = $this->line->packaging * $coeff;
+						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					}
+				}
 			}
 
 			$this->line->id = $rowid;

--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -343,6 +343,10 @@ class PropaleLigne extends CommonObjectLine
 	 */
 	public $multicurrency_total_ttc;
 
+		/**
+	 * @var float
+	 */
+	public $packaging;
 
 	/**
 	 * 	Class line Constructor
@@ -370,6 +374,9 @@ class PropaleLigne extends CommonObjectLine
 		$sql .= ' pd.fk_multicurrency, pd.multicurrency_code, pd.multicurrency_subprice, pd.multicurrency_total_ht, pd.multicurrency_total_tva, pd.multicurrency_total_ttc,';
 		$sql .= ' p.ref as product_ref, p.label as product_label, p.description as product_desc,';
 		$sql .= ' pd.date_start, pd.date_end, pd.product_type';
+		if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$sql .= ', p.packaging'; 
+		}
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'propaldet as pd';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON pd.fk_product = p.rowid';
 		$sql .= ' WHERE pd.rowid = '.((int) $rowid);
@@ -417,6 +424,10 @@ class PropaleLigne extends CommonObjectLine
 				$this->product_label	= $objp->product_label;
 				$this->product_desc		= $objp->product_desc;
 				$this->fk_unit          = $objp->fk_unit;
+
+				if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+					$this->packaging      = $objp->packaging;
+				}
 
 				$this->date_start       = $this->db->jdate($objp->date_start);
 				$this->date_end         = $this->db->jdate($objp->date_end);

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1634,6 +1634,20 @@ class Commande extends CommonOrder
 
 			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc);
 
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				$product = new Product($this->db);
+				$result = $product->fetch($fk_product);
+				if ($qty < $product->packaging) {
+					$qty = $product->packaging;
+				} else {
+					if (!empty($product->packaging) && (fmod((float) $qty, $product->packaging)  > 0.000001)) {
+						$coeff = intval((float) $qty / $product->packaging) + 1;
+						$qty = (float) $product->packaging * $coeff;
+						setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'mesgs');
+					}
+				}
+			}
+
 			// Clean vat code
 			$reg = array();
 			$vat_src_code = '';
@@ -2191,6 +2205,10 @@ class Commande extends CommonOrder
 				$line->weight_units     = $objp->weight_units;
 				$line->volume           = $objp->volume;
 				$line->volume_units     = $objp->volume_units;
+
+				if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+					$line->packaging = $objp->packaging;
+				}
 
 				$line->date_start       = $this->db->jdate($objp->date_start);
 				$line->date_end         = $this->db->jdate($objp->date_end);
@@ -3161,6 +3179,18 @@ class Commande extends CommonOrder
 			if (!empty($fk_parent_line) && !empty($staticline->fk_parent_line) && $fk_parent_line != $staticline->fk_parent_line) {
 				$rangmax = $this->line_max($fk_parent_line);
 				$this->line->rang = $rangmax + 1;
+			}
+
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				if ($qty < $this->line->packaging) {
+					$qty = $this->line->packaging;
+				} else {
+					if (!empty($this->line->packaging) && ($qty % $this->line->packaging) > 0) {
+						$coeff = intval($qty / $this->line->packaging) + 1;
+						$qty = $this->line->packaging * $coeff;
+						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					}
+				}
 			}
 
 			$this->line->id = $rowid;

--- a/htdocs/commande/class/orderline.class.php
+++ b/htdocs/commande/class/orderline.class.php
@@ -145,6 +145,10 @@ class OrderLine extends CommonOrderLine
 	 */
 	public $skip_update_total;
 
+	/**
+	 * @var float
+	 */
+	public $packaging;
 
 	/**
 	 *      Constructor
@@ -171,6 +175,9 @@ class OrderLine extends CommonOrderLine
 		$sql .= ' cd.fk_multicurrency, cd.multicurrency_code, cd.multicurrency_subprice, cd.multicurrency_total_ht, cd.multicurrency_total_tva, cd.multicurrency_total_ttc,';
 		$sql .= ' p.ref as product_ref, p.label as product_label, p.description as product_desc, p.tobatch as product_tobatch,';
 		$sql .= ' cd.date_start, cd.date_end, cd.vat_src_code';
+		if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$sql .= ', p.packaging'; 
+		}
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'commandedet as cd';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON cd.fk_product = p.rowid';
 		$sql .= ' WHERE cd.rowid = '.((int) $rowid);
@@ -224,6 +231,10 @@ class OrderLine extends CommonOrderLine
 			$this->product_desc     = $objp->product_desc;
 			$this->product_tobatch  = $objp->product_tobatch;
 			$this->fk_unit          = $objp->fk_unit;
+
+			if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				$this->packaging      = $objp->packaging;
+			}
 
 			$this->date_start       = $this->db->jdate($objp->date_start);
 			$this->date_end         = $this->db->jdate($objp->date_end);

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -180,6 +180,11 @@ class FactureLigne extends CommonInvoiceLine
 	 */
 	public $fk_prev_id;
 
+	/**
+	 * @var float
+	 */
+	public $packaging;
+
 
 	/**
 	 *      Constructor
@@ -211,6 +216,9 @@ class FactureLigne extends CommonInvoiceLine
 		$sql .= ' fd.multicurrency_total_tva,';
 		$sql .= ' fd.multicurrency_total_ttc,';
 		$sql .= ' p.ref as product_ref, p.label as product_label, p.description as product_desc';
+		if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$sql .= ', p.packaging'; 
+		}
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'facturedet as fd';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON fd.fk_product = p.rowid';
 		$sql .= ' WHERE fd.rowid = '.((int) $rowid);
@@ -276,6 +284,10 @@ class FactureLigne extends CommonInvoiceLine
 			$this->multicurrency_total_ht = $objp->multicurrency_total_ht;
 			$this->multicurrency_total_tva = $objp->multicurrency_total_tva;
 			$this->multicurrency_total_ttc = $objp->multicurrency_total_ttc;
+
+			if (getDolGlobalInt('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				$this->packaging      = $objp->packaging;
+			}
 
 			$this->fetch_optionals();
 

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -638,6 +638,12 @@ class modProduct extends DolibarrModules
 			));
 		}
 
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$this->import_fields_array[$r] = array_merge($this->import_fields_array[$r], array(
+				'p.packaging' => 'PackagingForThisProductSell',
+			));
+		}
+
 		if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice") || isModEnabled('margin')) {
 			$this->import_fields_array[$r] = array_merge($this->import_fields_array[$r], array('p.cost_price' => 'CostPrice'));
 		}
@@ -755,6 +761,13 @@ class modProduct extends DolibarrModules
 				)
 			));
 		}
+
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$import_sample = array_merge($import_sample, array(
+				'p.packaging' => "2",
+			));
+		}
+
 		$this->import_examplevalues_array[$r] = array_merge($import_sample, $import_extrafield_sample);
 		$this->import_updatekeys_array[$r] = array('p.ref' => 'Ref');
 		if (isModEnabled('barcode')) {

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -345,6 +345,9 @@ ProductSupplierDescription=Vendor description for the product
 UseProductSupplierPackaging=Use the "packaging" feature to round the quantities to some given multiples (when adding/updating line in a vendor documents, recalculate quantities and purchase prices according to the higher multiple set on the purchase prices of a product)
 PackagingForThisProduct=Packaging of quantities
 PackagingForThisProductDesc=You will automatically purchase a multiple of this quantity.
+UseProductCustomerPackaging=Use the "packaging" feature to round the quantities to some given multiples (when adding/updating line in a customer documents, recalculate quantities and sale prices according to the higher multiple set on the sale prices of a product)
+PackagingForThisProductSell=Packaging of quantities (sale)
+PackagingForThisProductSellDesc=You will automatically sell a multiple of this quantity.
 QtyRecalculatedWithPackaging=The quantity of the line were recalculated according to supplier packaging
 
 #Attributes

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -345,6 +345,9 @@ ProductSupplierDescription=Description du fournisseur du produit
 UseProductSupplierPackaging=Utilisez la fonction "conditionnement" pour arrondir les quantités à certains multiples donnés (lors de l'ajout/de la mise à jour d'une ligne, dans les documents d'un fournisseur, recalculez les quantités et les prix d'achat en fonction du multiple supérieur défini sur les prix d'achat d'un produit)
 PackagingForThisProduct=Conditionnement des quantités
 PackagingForThisProductDesc=Vous achèterez automatiquement un multiple de cette quantité.
+UseProductCustomerPackaging=Utilisez la fonction "conditionnement" pour arrondir les quantités à certains multiples donnés (lors de l'ajout/de la mise à jour d'une ligne, dans les documents d'un client, recalculez les quantités et les prix de vente en fonction du multiple supérieur défini sur les prix de vente d'un produit)
+PackagingForThisProductSell=Conditionnement des quantités (vente)
+PackagingForThisProductSellDesc=Vous vendrez automatiquement un multiple de cette quantité.
 QtyRecalculatedWithPackaging=La quantité de la ligne a été recalculée en fonction de l'emballage du fournisseur
 
 #Attributes

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -169,6 +169,11 @@ if ($action == 'other') {
 		$value = GETPOST('PRODUCT_USE_SUPPLIER_PACKAGING', 'alpha');
 		$res = dolibarr_set_const($db, "PRODUCT_USE_SUPPLIER_PACKAGING", $value, 'chaine', 0, '', $conf->entity);
 	}
+
+	if (GETPOSTISSET('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+		$value = GETPOST('PRODUCT_USE_CUSTOMER_PACKAGING', 'alpha');
+		$res = dolibarr_set_const($db, "PRODUCT_USE_CUSTOMER_PACKAGING", $value, 'chaine', 0, '', $conf->entity);
+	}
 }
 
 
@@ -638,6 +643,17 @@ if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
 	print '<td class="right">';
 	print ajax_constantonoff("PRODUIT_FOURN_TEXTS", array(), $conf->entity, 0, 0, 0, 0);
 	//print $form->selectyesno("activate_useProdFournDesc", (!empty($conf->global->PRODUIT_FOURN_TEXTS) ? $conf->global->PRODUIT_FOURN_TEXTS : 0), 1);
+	print '</td>';
+	print '</tr>';
+}
+
+// Use packaging during your sales
+if (isModEnabled("order") || isModEnabled("invoice")) {
+	print '<tr class="oddeven">';
+	print '<td>'.$form->textwithpicto($langs->trans("UseProductCustomerPackaging"), $langs->trans("PackagingForThisProductSellDesc")).'</td>';
+	print '<td align="right">';
+	print ajax_constantonoff("PRODUCT_USE_CUSTOMER_PACKAGING", array(), $conf->entity, 0, 0, 0, 0);
+	//print $form->selectyesno("activate_useProdSupplierPackaging", (!empty($conf->global->PRODUCT_USE_CUSTOMER_PACKAGING) ? $conf->global->PRODUCT_USE_CUSTOMER_PACKAGING : 0), 1);
 	print '</td>';
 	print '</tr>';
 }

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1438,6 +1438,9 @@ class Product extends CommonObject
 		$this->accountancy_code_sell_intra = trim($this->accountancy_code_sell_intra);
 		$this->accountancy_code_sell_export = trim($this->accountancy_code_sell_export);
 
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING') && !empty($this->packaging)) {
+			$this->packaging = $this->packaging;
+		}
 
 		$this->db->begin();
 
@@ -1588,6 +1591,9 @@ class Product extends CommonObject
 			$sql .= ", fk_price_expression = ".($this->fk_price_expression != 0 ? (int) $this->fk_price_expression : 'NULL');
 			$sql .= ", fk_user_modif = ".($user->id > 0 ? $user->id : 'NULL');
 			$sql .= ", mandatory_period = ".($this->mandatory_period);
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING') && !empty($this->packaging)) {
+				$sql .= ", packaging = ".($this->packaging);
+			}
 			// stock field is not here because it is a denormalized value from product_stock.
 			$sql .= " WHERE rowid = ".((int) $id);
 
@@ -2888,6 +2894,9 @@ class Product extends CommonObject
 		} else {
 			$sql .= " ppe.accountancy_code_buy, ppe.accountancy_code_buy_intra, ppe.accountancy_code_buy_export, ppe.accountancy_code_sell, ppe.accountancy_code_sell_intra, ppe.accountancy_code_sell_export,";
 		}
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$sql .= " p.packaging,";
+		}
 
 		// For MultiCompany
 		// PMP per entity & Stocks Sharings stock_reel includes only stocks shared with this entity
@@ -3066,6 +3075,10 @@ class Product extends CommonObject
 				$this->last_main_doc = $obj->last_main_doc;
 
 				$this->mandatory_period = $obj->mandatory_period;
+
+				if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+					$this->packaging = $obj->packaging;
+				}
 
 				$this->db->free($resql);
 

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -283,6 +283,11 @@ if (empty($reshook)) {
 		$psq = empty($newpsq) ? 0 : $newpsq;
 		$maxpricesupplier = $object->min_recommended_price();
 
+		// Packaging / Conditionnement
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			$packaging = GETPOST('packaging');
+		}
+
 		if (isModEnabled('dynamicprices')) {
 			$object->fk_price_expression = empty($eid) ? 0 : $eid; //0 discards expression
 
@@ -480,6 +485,11 @@ if (empty($reshook)) {
 
 		if (!$error) {
 			$db->begin();
+
+			// Packaging / Conditionnement
+			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+				$object->packaging = $packaging;
+			}
 
 			foreach ($pricestoupdate as $key => $val) {
 				$newprice = $val['price'];
@@ -1421,6 +1431,13 @@ if (getDolGlobalString('PRODUIT_MULTIPRICES') || getDolGlobalString('PRODUIT_CUS
 	}
 	print '</td></tr>';
 
+	// Packaging / Conditionnement
+	if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+		print '<tr class="field_price_label"><td>'.$form->textwithpicto($langs->trans("PackagingForThisProduct"), $langs->trans("PackagingForThisProductSellDesc")).'</td><td>';
+		print $object->packaging;
+		print '</td></tr>';
+	}
+
 	// Price Label
 	print '<tr class="field_price_label"><td>'.$langs->trans("PriceLabel").'</td><td>';
 	print $object->price_label;
@@ -1742,6 +1759,17 @@ if (($action == 'edit_price' || $action == 'edit_level_price') && $object->getRi
 		}
 		print '</td>';
 		print '</tr>';
+
+		// Packaging / Conditionnement
+		if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
+			print '<tr><td>';
+			print $form->textwithpicto($langs->trans("PackagingForThisProduct"), $langs->trans("PackagingForThisProductSellDesc"));
+			print '</td><td>';
+			$packaging = $object->packaging;
+			print '<input class="flat" name="packaging" size="5" value="'.$packaging.'">';
+			print '</td>';
+			print '</tr>';
+		}
 
 		// Price Label
 		print '<tr><td>';


### PR DESCRIPTION
From the sales prices, we set a quantity (conditioning of quantities) allowing a multiple of the quantity to be put in the customer's commercial documents.

Example: If the product must be sold by 2, we set 2 from the sale price and in each commercial part of the customer the product will automatically be 2. If 1 quantity is indicated on the addition or update of the line , the final quantity will be 2. If the quantity indicated is 3, then the final quantity will be 4.


![image](https://github.com/user-attachments/assets/3eecff68-58db-482a-abf6-0490857acd7b)

Customer order
![image](https://github.com/user-attachments/assets/8212eea5-61c0-472c-82c8-c7be3479369b)
![image](https://github.com/user-attachments/assets/1df927dd-e7e2-4af2-ab9e-48c92e9fe555)



