### PR TITLE
FIX: Time spent for timespent PDF

### DIFF
--- a/htdocs/core/modules/project/doc/pdf_timespent.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_timespent.modules.php
@@ -307,7 +307,7 @@ class pdf_timespent extends ModelePDFProjects
 					//$progress=($object->lines[$i]->progress?$object->lines[$i]->progress.'%':'');
 					$datestart = dol_print_date($object->lines[$i]->date_start, 'day');
 					$dateend = dol_print_date($object->lines[$i]->date_end, 'day');
-					$duration = convertSecondToTime((int) $object->lines[$i]->duration, 'allhourmin');
+					$duration = convertSecondToTime((int) $object->lines[$i]->duration_effective, 'allhourmin');
 
 					$showpricebeforepagebreak = 1;
 


### PR DESCRIPTION
Since V18 in the function getTasksArray `$tasks[$i]->duration = $obj->duration_effective` is replaced by `$tasks[$i]->duration_effective = $obj->duration_effective`. We must therefore refer to `$object->lines[$i]->duration_effective ` in the timespent PDF model

Before :
![image](https://github.com/user-attachments/assets/40ef3ea2-2d8b-485e-a393-0face79068b6)

After : 
![image](https://github.com/user-attachments/assets/3d276902-48fd-4e05-b35d-4407ba2a2d74)

