### PR TITLE
Fix customer prices multiprices

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -2361,6 +2361,8 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 		print '<table class="liste centpercent">'."\n";
 
 		if (count($prodcustprice->lines) > 0 || $search_soc) {
+			$extrafields->fetch_name_optionals_label("product_customer_price");
+			$custom_price_extralabels = !empty($extrafields->attributes["product_customer_price"]['label']) ? $extrafields->attributes["product_customer_price"]['label'] : '';
 			if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES_AND_MULTIPRICES')) {
 				$colspan = 10;
 			} else {
@@ -2369,8 +2371,8 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 			if ($mysoc->localtax1_assuj == "1" || $mysoc->localtax2_assuj == "1") {
 				$colspan++;
 			}
-			if (!empty($price_extralabels) && is_array($price_extralabels)) {
-				$colspan += count($price_extralabels);
+			if (!empty($custom_price_extralabels) && is_array($custom_price_extralabels)) {
+				$colspan += count($custom_price_extralabels);
 			}
 
 			print '<tr class="liste_titre">';


### PR DESCRIPTION
Don't display or update the extrafields of the product sheet on the selling prices tab.

Product extrafield
![image](https://github.com/user-attachments/assets/51dcc2f4-68c1-4f79-aebc-41b88b2ff6ee)
Product extrafield on selling prices, before
![image](https://github.com/user-attachments/assets/ad54194f-7a4f-497d-86dd-8ce7cede2d58)
And not product extrafield on selling prices, after
![image](https://github.com/user-attachments/assets/98adb1e8-a2d7-42ed-b59a-770fd21bb28e)

Correction on the update of price level extrafields and correction on the customer price table for the display of extrafields columns.

Before
![image](https://github.com/user-attachments/assets/a0586a48-2dee-4938-91e0-45312be70231)

After
![image](https://github.com/user-attachments/assets/6fa836b6-2528-49ab-9461-da2af1264c1a)


